### PR TITLE
Refactoring Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM alpine:latest
+FROM alpine:3.6
 
 MAINTAINER Franck Delage <franck@web82.fr>
 
-RUN apk update && apk upgrade
-RUN apk add --update nodejs \
-  make \
-  python \
-  bash \
-  git
-
 WORKDIR /usr/src/app
-RUN git clone https://github.com/napcs/node-livereload.git .
-RUN npm install
 
-ENTRYPOINT node bin/livereload.js /usr/src/livereload-watch -u true -d
+RUN apk add --update  nodejs \
+    && apk add --virtual build-dependencies nodejs-npm git \
+    && git clone https://github.com/napcs/node-livereload.git . \
+    && npm install \
+    && apk del build-dependencies \
+    && rm -rf /tmp/* /var/cache/apk/*
+
+ENTRYPOINT ["node", "bin/livereload.js"]
+CMD ["/usr/src/livereload-watch -u true -d"]

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ livereload:
     - /your/watch/directory:/usr/src/livereload-watch
 ```
 
-It's possible to override the `entrypoint` to tell livereload to watch more additional file extensions
+It's possible to override the `command` to tell livereload to watch more additional file extensions
 
 ```yml
 livereload:
   image: franckdelage/livereload
-  entrypoint: node bin/livereload.js /usr/src/livereload-watch -u true -d --exts 'phtml,sass'
+  command: "/usr/src/livereload-watch -u true -d --exts 'phtml,sass'"
 ```
 
 > `--exts 'phtml,sass'` are additional file extentions. Check [Livereload Command Options](https://github.com/napcs/node-livereload#command-line-options) for more options.
-  


### PR DESCRIPTION
- remove unused dependencies 
- use alpine tagged version
- split ENTRYPOINT for ENTRYPOINT+CMD usage

The result is a [16Mo compressed image :)](https://hub.docker.com/r/cethy/alpine-livereload/tags/) (vs 42Mo actually)